### PR TITLE
Add tokenize API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ By default, the api is hosted on `http://127.0.0.1:19633`. To change this, edit 
 
 - [/ankiFields](./docs/api_paths/ankiFields.md)
 
+- [/tokenize](./docs/api_paths/tokenize.md)
+
 ## Examples
 
 [Yomitan API Request Example Python](./request_example.py)

--- a/docs/api_paths/tokenize.md
+++ b/docs/api_paths/tokenize.md
@@ -1,0 +1,54 @@
+# `tokenize`
+
+Returns tokenized text segments for input text, including readings.
+
+## Request Options
+
+- Request method: `POST`
+
+- Body:
+
+    - `text` (`string`): The text to tokenize and parse.
+
+    - `scanLength` (`number`): Maximum length to scan for each segment. Lower values provide faster processing while higher values can capture longer compound words.
+
+## Request Example
+
+```json
+{
+    "text": "自民党の臨時の総裁選挙が実施されるかどうか",
+    "scanLength": 10
+}
+```
+
+## Response Example (200)
+
+The response contains an array with parsing results from Yomitan's internal `parseText` method. Each element in the content array represents a parsed segment with its reading(s) and text.
+
+<details>
+<summary>Expand to view response</summary>
+
+```json
+[
+  {
+    "content": [
+      [{ "reading": "じみんとう", "text": "自民党"}],
+      [{ "reading": "", "text": "の"}],
+      [{ "reading": "りんじ", "text": "臨時"}],
+      [{ "reading": "", "text": "の"}],
+      [{ "reading": "そうさい", "text": "総裁"}],
+      [{ "reading": "せん", "text": "選"}],
+      [{ "reading": "きょ", "text": "挙"}],
+      [{ "reading": "", "text": "が"}],
+      [{ "reading": "じっし", "text": "実施"}],
+      [{ "reading": "", "text": "される"}],
+      [{ "reading": "", "text": "かどうか"}],
+    ],
+    "dictionary": null,
+    "id": "scan",
+    "source": "scanning-parser"
+  }
+]
+```
+
+</details>

--- a/request_example.py
+++ b/request_example.py
@@ -59,6 +59,16 @@ def anki_fields_kanji() -> None:
     print(response)
     print(elide(response.text))
 
+def tokenize() -> None:
+    print("Requesting tokenize:")
+    params = {
+        "text": "自民党の総裁選挙",
+        "scanLength": 10,
+    }
+    response = requests.post(request_url + "/tokenize", json = params, timeout = request_timeout)
+    print(response)
+    print(elide(response.text))
+
 print("Yomitan API request example demo")
 print("Only the first 100 characters of the result data for each request will be printed")
 print("--------------------------------------------------")
@@ -67,3 +77,4 @@ term_entries()
 kanji_entries()
 anki_fields_term()
 anki_fields_kanji()
+tokenize()


### PR DESCRIPTION
Added documentation for the `/tokenize` endpoint. (See https://github.com/yomidevs/yomitan/pull/2162)

